### PR TITLE
♻ ✅ Add table driven test

### DIFF
--- a/lib/core/entity.dart
+++ b/lib/core/entity.dart
@@ -1,4 +1,4 @@
-import 'package:equatable/equatable.dart';
+import 'package:equatable/equatable.dart'; 
 import 'consts.dart';
 
 import 'errors/validation_error.dart';
@@ -16,16 +16,12 @@ abstract class Entity extends Equatable {
   List<ValidationInfo> validate() {
     final List<ValidationInfo> errors = [];
 
-    validateId(this.id, errors);
-
     return errors;
   }
 
   static validateId(final String id, final List<ValidationInfo> errors) {
-    if (id == null) {
+    if (id == null || id == '') {
       errors.add(new ValidationInfo(type: ValidationTypes.idNotDefined));
-    } else if (id == '') {
-      errors.add(new ValidationInfo(type: ValidationTypes.idIsEmpty));
     }
   }
 

--- a/lib/core/errors/validation_error.dart
+++ b/lib/core/errors/validation_error.dart
@@ -28,6 +28,5 @@ enum ValidationTypes {
   undefined,
   dateIsInTheFuture,
   idNotDefined,
-  idIsEmpty,
   nameTooShort,
 }

--- a/lib/features/piece/domain/entities/piece_entity.dart
+++ b/lib/features/piece/domain/entities/piece_entity.dart
@@ -41,6 +41,8 @@ class PieceEntity extends Entity {
   }
 
   /// Create a copy of the piece, overriding some elements
+  /// It's not possible to unset elements, you have to do that after the .copy()
+  /// method is called. When passing in null, it will use this value instead.
   /// @return copy of this piece
   PieceEntity copy({
     id,

--- a/lib/features/piece/domain/entities/practice_entity.dart
+++ b/lib/features/piece/domain/entities/practice_entity.dart
@@ -3,13 +3,13 @@ import 'package:meta/meta.dart';
 import '../../../../core/entity.dart';
 import '../../../../core/errors/validation_error.dart';
 
-class Practice extends Entity {
+class PracticeEntity extends Entity {
   final String pieceId;
   final DateTime date;
   final PracticeMistakes technicalMistakes;
   final PracticeMistakes memoryFlubs;
 
-  Practice({
+  PracticeEntity({
     String id,
     @required this.pieceId,
     @required this.date,
@@ -46,14 +46,14 @@ class Practice extends Entity {
     return errors;
   }
 
-  Practice copy({
+  PracticeEntity copy({
     String id,
     String pieceId,
     DateTime date,
     PracticeMistakes technicalMistakes,
     PracticeMistakes memoryFlubs,
   }) {
-    return new Practice(
+    return new PracticeEntity(
       id: id != null ? id : this.id,
       pieceId: pieceId != null ? pieceId : this.pieceId,
       date: date != null ? date : this.date,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,13 +148,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0-nullsafety.3"
-  faker:
-    dependency: "direct dev"
-    description:
-      name: faker
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   ffi:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.3
-  faker: ^1.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/core/entity_test.dart
+++ b/test/core/entity_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_musical_repertoire/core/entity.dart';
-import 'package:my_musical_repertoire/core/errors/validation_error.dart';
 
 class BaseEntity extends Entity {
   BaseEntity(String id) : super(id);
@@ -8,24 +7,40 @@ class BaseEntity extends Entity {
 
 void main() {
   group("Base Entity #entity #cold", () {
-    Entity entity;
+    test("Valid Entity", () {
+      List<BaseEntity> inputs = [
+        new BaseEntity("0"),
+        new BaseEntity("dde24271-af67-4ccd-809c-12dda1402a5e"),
+        new BaseEntity(""),
+        new BaseEntity(null),
+      ];
 
-    test("Valid id", () {
-      entity = new BaseEntity("0");
-
-      expect(entity.validate(), isEmpty);
+      for (BaseEntity entity in inputs) {
+        expect(entity.validate(), isEmpty);
+      }
     });
 
-    test("Id is null", () {
-      entity = new BaseEntity(null);
-      expect(entity.validate(),
-          equals([new ValidationInfo(type: ValidationTypes.idNotDefined)]));
+    test("should be equal when both entities have same properties", () {
+      List<List<BaseEntity>> testData = [
+        [new BaseEntity("id"), new BaseEntity("id")],
+        [new BaseEntity(null), new BaseEntity(null)],
+      ];
+
+      for (List<BaseEntity> test in testData) {
+        expect(test[0], test[1]);
+      }
     });
 
-    test("Id is empty", () {
-      entity = new BaseEntity("");
-      expect(entity.validate(),
-          equals([new ValidationInfo(type: ValidationTypes.idIsEmpty)]));
+    test("should not be equal when changing any property", () {
+      List<List<BaseEntity>> testData = [
+        [new BaseEntity("id"), new BaseEntity(null)],
+        [new BaseEntity("id"), new BaseEntity("different")],
+        [new BaseEntity(null), new BaseEntity("32b8f9a8-0428-44e1-88c0-1b0098fd9c1f")],
+      ];
+
+      for (List<BaseEntity> test in testData) {
+        expect(test[0], isNot(test[1]));
+      }
     });
   });
 }

--- a/test/features/piece/data/models/piece_model_test.dart
+++ b/test/features/piece/data/models/piece_model_test.dart
@@ -44,11 +44,11 @@ void main() {
         expect(result, expectedMap);
       });
 
-      test("should return a map with all fields excluding last practiced", () {
+      test("should return a map with all fields, lastpractice set to null", () {
         final expectedMap = {
           "id": pieceMissingLastPractice.id,
           "name": pieceMissingLastPractice.name,
-          "lastPracticed": pieceMissingLastPractice.lastPracticed,
+          "lastPracticed": null,
         };
         final result = pieceMissingLastPractice.toMap();
         expect(result, expectedMap);

--- a/test/features/piece/domain/entities/piece_test.dart
+++ b/test/features/piece/domain/entities/piece_test.dart
@@ -1,20 +1,17 @@
-import 'package:faker/faker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_musical_repertoire/core/consts.dart';
 import 'package:my_musical_repertoire/core/errors/validation_error.dart';
 import 'package:my_musical_repertoire/features/piece/domain/entities/piece_entity.dart';
 
-const _faker = Faker();
-
 PieceEntity fakerPiece({String name, DateTime date}) {
   if (name == null) {
-    name = _faker.person.firstName();
+    name = "Moonlight Sonata";
   }
   if (date == null) {
-    date = _faker.date.dateTime(minYear: 2018, maxYear: 2019);
+    date = new DateTime(2019, 03, 14, 23, 59);
   }
   return new PieceEntity(
-    id: _faker.guid.guid(),
+    id: "e085aac6-096c-41e8-9214-242b656691db",
     name: name,
     lastPracticed: date,
   );

--- a/test/features/piece/domain/entities/piece_test.dart
+++ b/test/features/piece/domain/entities/piece_test.dart
@@ -20,12 +20,12 @@ PieceEntity fakerPiece({String name, DateTime date}) {
 PieceEntity copyFrom(
   PieceEntity original, {
   String name,
-  DateTime date,
+  DateTime lastPracticed,
 }) {
   return new PieceEntity(
     id: original.id,
     name: name != null ? name : original.name,
-    lastPracticed: date != null ? date : original.lastPracticed,
+    lastPracticed: lastPracticed != null ? lastPracticed : original.lastPracticed,
   );
 }
 
@@ -73,32 +73,43 @@ void main() {
     });
 
     test("Not be equal to itself when changing any property", () {
-      // Name
-      copy = copyFrom(original, name: 'different');
-      expect(copy, isNot(original));
+      List<PieceEntity> testData = [
+        // Name
+        new PieceEntity(id: original.id, name: 'different', lastPracticed: original.lastPracticed),
+        new PieceEntity(id: original.id, name: null, lastPracticed: original.lastPracticed),
+        // Date
+        new PieceEntity(id: original.id, name: original.name, lastPracticed: new DateTime(2017)),
+        new PieceEntity(id: original.id, name: original.name, lastPracticed: null),
+      ];
 
-      // Date
-      copy = copyFrom(original, date: new DateTime(2017));
-      expect(copy, isNot(original));
+      for (copy in testData) {
+        expect(copy, isNot(original));
+      }
     });
 
     test('copy() should be equal to the original', () {
-      copy = original.copy();
-      expect(copy, original);
+      List<PieceEntity> testData = [
+        original.copy(),
+        original.copy(id: null),
+        original.copy(name: null),
+        original.copy(lastPracticed: null),
+      ];
+
+      for (copy in testData) {
+        expect(copy, original);
+      }
     });
 
     test("copy(param) with a parameter should not be equal to the original", () {
-      // Id
-      copy = original.copy(id: 'different');
-      expect(copy, isNot(original));
+      List<PieceEntity> testData = [
+        original.copy(id: 'different'),
+        original.copy(name: 'different'),
+        original.copy(lastPracticed: new DateTime(2017)),
+      ];
 
-      // Name
-      copy = original.copy(name: 'different');
-      expect(copy, isNot(original));
-
-      // Date
-      copy = original.copy(lastPracticed: new DateTime(2017));
-      expect(copy, isNot(original));
+      for (copy in testData) {
+        expect(copy, isNot(original));
+      }
     });
   });
 }

--- a/test/features/piece/domain/entities/practice_test.dart
+++ b/test/features/piece/domain/entities/practice_test.dart
@@ -1,13 +1,10 @@
-import 'package:faker/faker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_musical_repertoire/core/errors/validation_error.dart';
 import 'package:my_musical_repertoire/features/piece/domain/entities/practice.dart';
 
-const _faker = Faker();
-
 Practice fakerPractice({String id, DateTime date}) {
   if (id == null) {
-    id = _faker.guid.guid();
+    id = "8a079f87-be77-439c-99c1-1675b59d7bd5";
   }
   if (id == 'null') {
     id = null;
@@ -16,7 +13,7 @@ Practice fakerPractice({String id, DateTime date}) {
     date = DateTime.now();
   }
   return new Practice(
-    id: _faker.guid.guid(),
+    id: "a669fd47-933c-4df7-89b9-7b085d1767fb",
     pieceId: id,
     date: date,
     technicalMistakes: PracticeMistakes.none,

--- a/test/features/piece/domain/entities/practice_test.dart
+++ b/test/features/piece/domain/entities/practice_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_musical_repertoire/core/errors/validation_error.dart';
-import 'package:my_musical_repertoire/features/piece/domain/entities/practice.dart';
+import 'package:my_musical_repertoire/features/piece/domain/entities/piece_entity.dart';
+import 'package:my_musical_repertoire/features/piece/domain/entities/practice_entity.dart';
 
-Practice fakerPractice({String id, DateTime date}) {
+PracticeEntity fakerPractice({String id, DateTime date}) {
   if (id == null) {
     id = "8a079f87-be77-439c-99c1-1675b59d7bd5";
   }
@@ -12,8 +13,8 @@ Practice fakerPractice({String id, DateTime date}) {
   if (date == null) {
     date = DateTime.now();
   }
-  return new Practice(
-    id: "a669fd47-933c-4df7-89b9-7b085d1767fb",
+  return new PracticeEntity(
+    id: null,
     pieceId: id,
     date: date,
     technicalMistakes: PracticeMistakes.none,
@@ -21,14 +22,14 @@ Practice fakerPractice({String id, DateTime date}) {
   );
 }
 
-Practice copyFrom(
-  Practice original, {
+PracticeEntity copyFrom(
+  PracticeEntity original, {
   String pieceId,
   DateTime date,
   PracticeMistakes technicalMistakes,
   PracticeMistakes memoryFlubs,
 }) {
-  return new Practice(
+  return new PracticeEntity(
     id: original.id,
     pieceId: pieceId != null ? pieceId : original.pieceId,
     date: date != null ? date : original.date,
@@ -39,9 +40,9 @@ Practice copyFrom(
 
 void main() {
   group("Practice Entity should (#entity #cold) ->", () {
-    Practice practice;
-    Practice original;
-    Practice copy;
+    PracticeEntity practice;
+    PracticeEntity original;
+    PracticeEntity copy;
 
     setUp(() {
       original = fakerPractice();
@@ -53,13 +54,14 @@ void main() {
     });
 
     test("Validate that id is not defined", () {
-      practice = fakerPractice(id: 'null');
-      expect(practice.validate(), equals([new ValidationInfo(type: ValidationTypes.idNotDefined)]));
-    });
+      List<PracticeEntity> testData = [
+        fakerPractice(id: 'null'),
+        fakerPractice(id: ''),
+      ];
 
-    test("Validate that id is empty", () {
-      practice = fakerPractice(id: "");
-      expect(practice.validate(), equals([new ValidationInfo(type: ValidationTypes.idIsEmpty)]));
+      for (practice in testData) {
+        expect(practice.validate(), equals([new ValidationInfo(type: ValidationTypes.idNotDefined)]));
+      }
     });
 
     test("Validate that date is in the future", () {
@@ -77,48 +79,76 @@ void main() {
     });
 
     test("Not be equal to itself when changing any property", () {
-      // Piece id
-      copy = copyFrom(original, pieceId: 'different');
-      expect(copy, isNot(original));
+      List<PracticeEntity> testData = [
+        new PracticeEntity(
+          id: 'different',
+          pieceId: original.pieceId,
+          date: original.date,
+          technicalMistakes: original.technicalMistakes,
+          memoryFlubs: original.memoryFlubs,
+        ),
+        new PracticeEntity(
+          id: original.id,
+          pieceId: 'different',
+          date: original.date,
+          technicalMistakes: original.technicalMistakes,
+          memoryFlubs: original.memoryFlubs,
+        ),
+        new PracticeEntity(
+          id: original.id,
+          pieceId: original.pieceId,
+          date: new DateTime(2019),
+          technicalMistakes: original.technicalMistakes,
+          memoryFlubs: original.memoryFlubs,
+        ),
+        new PracticeEntity(
+          id: original.id,
+          pieceId: original.pieceId,
+          date: original.date,
+          technicalMistakes: PracticeMistakes.everywhere,
+          memoryFlubs: original.memoryFlubs,
+        ),
+        new PracticeEntity(
+          id: original.id,
+          pieceId: original.pieceId,
+          date: original.date,
+          technicalMistakes: original.technicalMistakes,
+          memoryFlubs: PracticeMistakes.everywhere,
+        ),
+      ];
 
-      // Date
-      copy = copyFrom(original, date: new DateTime(2019));
-      expect(copy, isNot(original));
-
-      // Technical mistakes
-      copy = copyFrom(original, technicalMistakes: PracticeMistakes.everywhere);
-      expect(copy, isNot(original));
-
-      // Memory flubs
-      copy = copyFrom(original, memoryFlubs: PracticeMistakes.everywhere);
-      expect(copy, isNot(original));
+      for (copy in testData) {
+        expect(copy, isNot(original));
+      }
     });
 
     test("copy() should be equal to the original", () {
-      copy = original.copy();
-      expect(copy, original);
+      List<PracticeEntity> testData = [
+        original.copy(),
+        original.copy(id: null),
+        original.copy(pieceId: null),
+        original.copy(date: null),
+        original.copy(technicalMistakes: null),
+        original.copy(memoryFlubs: null),
+      ];
+
+      for (copy in testData) {
+        expect(copy, original);
+      }
     });
 
     test("copy(param) with a parameter should not be equal to the original", () {
-      // Id
-      copy = original.copy(id: 'different');
-      expect(copy, isNot(original));
+      List<PracticeEntity> testData = [
+        original.copy(id: 'different'),
+        original.copy(pieceId: 'different'),
+        original.copy(date: new DateTime(2019)),
+        original.copy(technicalMistakes: PracticeMistakes.everywhere),
+        original.copy(memoryFlubs: PracticeMistakes.everywhere),
+      ];
 
-      // Piece id
-      copy = original.copy(pieceId: 'different');
-      expect(copy, isNot(original));
-
-      // Date
-      copy = original.copy(date: new DateTime(2019));
-      expect(copy, isNot(original));
-
-      // Technical mistakes
-      copy = original.copy(technicalMistakes: PracticeMistakes.everywhere);
-      expect(copy, isNot(original));
-
-      // Memory flubs
-      copy = original.copy(memoryFlubs: PracticeMistakes.everywhere);
-      expect(copy, isNot(original));
+      for (copy in testData) {
+        expect(copy, isNot(original));
+      }
     });
   });
 }

--- a/test/features/piece/domain/usecases/piece_remove_test.dart
+++ b/test/features/piece/domain/usecases/piece_remove_test.dart
@@ -1,11 +1,8 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:faker/faker.dart';
 import 'package:mockito/mockito.dart';
 import 'package:my_musical_repertoire/features/piece/domain/repositories/piece_repository.dart';
 import 'package:my_musical_repertoire/features/piece/domain/usecases/piece_remove.dart';
-
-const _faker = Faker();
 
 class _MockPieceRepository extends Mock implements PieceRepository {}
 
@@ -20,7 +17,7 @@ void main() {
     });
 
     test('Call the repository to remove the piece with the specified id', () async {
-      final String id = _faker.guid.guid();
+      final String id = "9af5b94b-509d-47f2-a774-634c6e6d7902";
       when(mockPieceRepository.removePiece(any)).thenAnswer((_) async => Right(id));
 
       final result = await usecase(id);


### PR DESCRIPTION
Make the tests more clean using a table driven approach.
Also renamed Practice to PracticeEntity for consistency.
Merged ValidationTypes.idIsEmpty into idNotDefined