### PR TITLE
feat: piece durations, multi-piece maintenance, proportional redistri…

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -205,11 +205,11 @@ Tailwind classes are the same via NativeWind: `<View className="flex-1 p-4 bg-wh
   - [ ] Some self-estimation bars uses numbers, some text. We should be consistent. Ideally the "best" should be at the same location (to the right). For examlp effort should be low, but it's on the left side. I think it's better to have text than numbers. However, we need to make sure that works even when the text doesn't fit (should maybe be smaller text so always fits?)
   - [x] Always show metronome button, but should be disabled when BPM is not set.
   - [x] When adding piece, section, or technique. Title is focused on web, but immediately blurred. Try to fix with playwright.
-  - [ ] Add duration for pieces. This will help with the session plan generator to estimate how much time a full playthrough of a piece it will take.
+  - [x] Add duration for pieces. This will help with the session plan generator to estimate how much time a full playthrough of a piece it will take.
         During a session, if the piece is selected as a whole but does not have a duration. Suggest using the time elapsed of that block to estimate the piece duration after the user has pressed save and continue.
+  - [x] When practicing maintenance pieces, it should pick many if many are available instead of assigning 12 minutes to one piece
+  - [x] Instead of carrying the session time forward to the next block if we're missing or have removed a section it should be distributed "evenly" across the remaining blocks. For example, if we have 30 minutes and 10 minutes would go to technique, 5 minutes to sight-reading, and 15 minutes to repertoire. We should distribute the 5 minutes like this: techniue = (10/30)*5 = 1.66 minutes, sight-reading = (5/30)*5 = 0.83 minutes, and repertoire = (15/30)\*5 = 2.5 minutes. This way we keep the same proportions as the original plan.
   - [ ] When practicing a anything, it would be good to see the last log for that piece/section/technique to have a reference point. This should be displayed both in the individual practice screens as well as in the session (which probably reuses the same practice screens).
-  - [ ] When practicing maintenance pieces, it should pick many if many are available instead of assigning 12 minutes to one piece
-  - [ ] Instead of carrying the session time forward to the next block if we're missing or have removed a section it should be distributed "evenly" across the remaining blocks. For example, if we have 30 minutes and 10 minutes would go to technique, 5 minutes to sight-reading, and 15 minutes to repertoire. We should distribute the 5 minutes like this: techniue = (10/30)*5 = 1.66 minutes, sight-reading = (5/30)*5 = 0.83 minutes, and repertoire = (15/30)\*5 = 2.5 minutes. This way we keep the same proportions as the original plan.
 
 #### Bugs
 
@@ -229,18 +229,8 @@ Tailwind classes are the same via NativeWind: `<View className="flex-1 p-4 bg-wh
   - [ ] When two adjacent sections are individually stable, suggest a **seam exercise** (last 2 bars of A + first 2 bars of B)
   - [ ] After seam is practiced, suggest a **join block** (A+B combined)
   - [ ] Nudge the student when sections look stable enough to add the next section (student still decides)
-- [ ] Ask the student how much time is available before building the plan
-- [ ] Let the student choose a session emphasis/template
-  - [ ] Short-session templates: `technique-first`, `reading-first`, `repertoire-only maintenance`
-  - [ ] Medium and long-session templates with editable minutes per block
 - [ ] Use duration bands so block structure changes for short, medium, and long sessions
-- [ ] Generate a short session plan of concrete exercise blocks
-  - [ ] Short sessions: one supporting block (`technique` or `sight-reading`) plus the main repertoire block
-  - [ ] Repertoire blocks: at least one `learning`, weak-spot repair, or `maintenance` / continuity block when applicable
-  - [ ] Longer sessions should add depth before adding too much variety
-  - [ ] Repertoire is app-assigned first; technique and sight-reading remain template-driven initially
 - [ ] Explain why each suggested block was chosen
-- [ ] Replace the current simple overview sort with plan-based suggestions
 - [ ] Touch up UI/UX and fix any discrepancies
 
 ### Phase 5: Recommendation Engine Refinement

--- a/app/(app)/piece/[id]/edit.tsx
+++ b/app/(app)/piece/[id]/edit.tsx
@@ -49,6 +49,11 @@ export default function EditPieceScreen() {
 	const [targetTempoBpmText, setTargetTempoBpmText] = useState(
 		piece?.targetTempoBpm?.toString() ?? "",
 	);
+	const [durationMinutesText, setDurationMinutesText] = useState(
+		piece?.durationSeconds != null
+			? String(Math.round(piece.durationSeconds / 60))
+			: "",
+	);
 	const [difficulty, setDifficulty] = useState<string | null>(
 		piece?.difficulty?.toString() ?? null,
 	);
@@ -58,6 +63,7 @@ export default function EditPieceScreen() {
 	const [titleError, setTitleError] = useState<string | null>(null);
 	const [composerError, setComposerError] = useState<string | null>(null);
 	const [bpmError, setBpmError] = useState<string | null>(null);
+	const [durationError, setDurationError] = useState<string | null>(null);
 	const hasSeeded = useRef(false);
 
 	const validateTitle = (): string | null => {
@@ -86,6 +92,18 @@ export default function EditPieceScreen() {
 		setBpmError(validateBpm(targetTempoBpmText));
 	};
 
+	const validateDuration = (text: string): string | null => {
+		if (!text.trim()) return null;
+		const n = Number.parseInt(text.trim(), 10);
+		return Number.isNaN(n) || n < 1 || n > 600
+			? t("error.durationInvalid")
+			: null;
+	};
+
+	const handleDurationBlur = () => {
+		setDurationError(validateDuration(durationMinutesText));
+	};
+
 	// Seed form once the piece loads from Firestore (avoids resetting user edits on re-renders)
 	useEffect(() => {
 		if (piece && !hasSeeded.current) {
@@ -94,6 +112,11 @@ export default function EditPieceScreen() {
 			setState(piece.state);
 			setLearningPhase(piece.learningPhase ?? null);
 			setTargetTempoBpmText(piece.targetTempoBpm?.toString() ?? "");
+			setDurationMinutesText(
+				piece.durationSeconds != null
+					? String(Math.round(piece.durationSeconds / 60))
+					: "",
+			);
 			setDifficulty(piece.difficulty?.toString() ?? null);
 			setNotes(piece.notes ?? "");
 			hasSeeded.current = true;
@@ -126,11 +149,17 @@ export default function EditPieceScreen() {
 		const composerErr = validateComposer();
 		const bpmErr = validateBpm(targetTempoBpmText);
 		setBpmError(bpmErr);
-		if (titleErr || composerErr || bpmErr) return;
+		const durationErr = validateDuration(durationMinutesText);
+		setDurationError(durationErr);
+		if (titleErr || composerErr || bpmErr || durationErr) return;
 		if (!id) return;
 
 		const targetTempoBpm = targetTempoBpmText.trim()
 			? Number.parseInt(targetTempoBpmText.trim(), 10) || null
+			: null;
+
+		const durationSeconds = durationMinutesText.trim()
+			? Number.parseInt(durationMinutesText.trim(), 10) * 60
 			: null;
 
 		const parsedDifficulty = difficulty
@@ -147,6 +176,7 @@ export default function EditPieceScreen() {
 				state,
 				learningPhase: state === "learning" ? learningPhase : null,
 				targetTempoBpm,
+				durationSeconds,
 				difficulty: parsedDifficulty,
 				notes: notes.trim() || null,
 			});
@@ -219,6 +249,21 @@ export default function EditPieceScreen() {
 				/>
 				<HelperText type="error" visible={!!bpmError}>
 					{bpmError ?? ""}
+				</HelperText>
+			</View>
+
+			<View>
+				<TextInput
+					label={t("screen.editPiece.durationLabel")}
+					value={durationMinutesText}
+					onChangeText={setDurationMinutesText}
+					mode="outlined"
+					keyboardType="numeric"
+					error={!!durationError}
+					onBlur={handleDurationBlur}
+				/>
+				<HelperText type="error" visible={!!durationError}>
+					{durationError ?? ""}
 				</HelperText>
 			</View>
 

--- a/app/(app)/piece/add.tsx
+++ b/app/(app)/piece/add.tsx
@@ -38,11 +38,13 @@ export default function AddPieceScreen() {
 	const [composer, setComposer] = useState("");
 	const [state, setState] = useState<PieceState>("learning");
 	const [targetTempoBpmText, setTargetTempoBpmText] = useState("");
+	const [durationMinutesText, setDurationMinutesText] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [titleError, setTitleError] = useState<string | null>(null);
 	const [composerError, setComposerError] = useState<string | null>(null);
 	const [bpmError, setBpmError] = useState<string | null>(null);
+	const [durationError, setDurationError] = useState<string | null>(null);
 	const titleTouched = useRef(false);
 	const titleInputRef = useAutoFocusOnMount<{ focus: () => void }>();
 
@@ -70,6 +72,18 @@ export default function AddPieceScreen() {
 		setBpmError(validateBpm(targetTempoBpmText));
 	};
 
+	const validateDuration = (text: string): string | null => {
+		if (!text.trim()) return null;
+		const n = Number.parseInt(text.trim(), 10);
+		return Number.isNaN(n) || n < 1 || n > 600
+			? t("error.durationInvalid")
+			: null;
+	};
+
+	const handleDurationBlur = () => {
+		setDurationError(validateDuration(durationMinutesText));
+	};
+
 	const stateOptions = PIECE_STATES.map((s) => ({
 		value: s,
 		label: t(`piece.state.${s}`),
@@ -80,17 +94,29 @@ export default function AddPieceScreen() {
 		const composerErr = validateComposer();
 		const bpmErr = validateBpm(targetTempoBpmText);
 		setBpmError(bpmErr);
-		if (titleErr || composerErr || bpmErr) return;
+		const durationErr = validateDuration(durationMinutesText);
+		setDurationError(durationErr);
+		if (titleErr || composerErr || bpmErr || durationErr) return;
 
 		const targetTempoBpm = targetTempoBpmText.trim()
 			? Number.parseInt(targetTempoBpmText.trim(), 10) || null
+			: null;
+
+		const durationSeconds = durationMinutesText.trim()
+			? Number.parseInt(durationMinutesText.trim(), 10) * 60
 			: null;
 
 		setLoading(true);
 		setError(null);
 
 		try {
-			await addPiece(title.trim(), composer.trim(), state, targetTempoBpm);
+			await addPiece(
+				title.trim(),
+				composer.trim(),
+				state,
+				targetTempoBpm,
+				durationSeconds,
+			);
 			router.back();
 		} catch {
 			setError(t("error.firebase"));
@@ -152,6 +178,21 @@ export default function AddPieceScreen() {
 				/>
 				<HelperText type="error" visible={!!bpmError}>
 					{bpmError ?? ""}
+				</HelperText>
+			</View>
+
+			<View>
+				<TextInput
+					label={t("screen.addPiece.durationLabel")}
+					value={durationMinutesText}
+					onChangeText={setDurationMinutesText}
+					mode="outlined"
+					keyboardType="numeric"
+					error={!!durationError}
+					onBlur={handleDurationBlur}
+				/>
+				<HelperText type="error" visible={!!durationError}>
+					{durationError ?? ""}
 				</HelperText>
 			</View>
 

--- a/app/(app)/session/coach.tsx
+++ b/app/(app)/session/coach.tsx
@@ -2,12 +2,22 @@ import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
-import { ActivityIndicator, Text, useTheme } from "react-native-paper";
+import {
+	ActivityIndicator,
+	Button,
+	Dialog,
+	HelperText,
+	Portal,
+	Text,
+	TextInput,
+	useTheme,
+} from "react-native-paper";
 import { PiecePracticeContent } from "@/app/(app)/piece/[id]/practice";
 import { TechniquePracticeContent } from "@/app/(app)/technique/[id]/practice";
-import { CoachShell } from "@/components/practice/CoachShell";
+import { CoachShell, formatMMSS } from "@/components/practice/CoachShell";
 import { useAuth } from "@/contexts/AuthContext";
 import { type CoachContextValue, CoachProvider } from "@/contexts/CoachContext";
+import { usePieces, useUpdatePiece } from "@/hooks/use-pieces";
 import type {
 	ActiveSession,
 	BlockExecutionState,
@@ -30,9 +40,16 @@ export default function CoachScreen() {
 	const theme = useTheme();
 	const router = useRouter();
 	const { user } = useAuth();
+	const { pieces } = usePieces();
+	const { updatePiece } = useUpdatePiece();
 	const [session, setSession] = useState<ActiveSession | null>(null);
 	const [loaded, setLoaded] = useState(false);
 	const [saving, setSaving] = useState(false);
+	const [durationPrompt, setDurationPrompt] = useState<{
+		pieceId: string;
+		title: string;
+		elapsedSeconds: number;
+	} | null>(null);
 	const [, setTick] = useState(0);
 	const cueFiredForIndexRef = useRef<Set<number>>(new Set());
 
@@ -177,11 +194,50 @@ export default function CoachScreen() {
 					return;
 				}
 			}
+			// Maintenance whole-piece block with no known duration → capture it
+			// from the elapsed play-through time before advancing.
+			if (
+				currentBlock.kind === "repertoire-maintenance" &&
+				currentBlock.pieceId
+			) {
+				const piece = pieces.find((p) => p.id === currentBlock.pieceId);
+				if (piece && piece.durationSeconds == null) {
+					setDurationPrompt({
+						pieceId: currentBlock.pieceId,
+						title: currentBlock.title ?? piece.title,
+						elapsedSeconds: diffSec(session.currentBlockStartedAt),
+					});
+					return;
+				}
+			}
 			await advance("completed");
 		} finally {
 			setSaving(false);
 		}
-	}, [session, currentBlock, advance]);
+	}, [session, currentBlock, advance, pieces]);
+
+	const handleDurationSave = useCallback(
+		async (minutes: number) => {
+			const prompt = durationPrompt;
+			setDurationPrompt(null);
+			if (prompt) {
+				try {
+					await updatePiece(prompt.pieceId, {
+						durationSeconds: minutes * 60,
+					});
+				} catch {
+					// Non-fatal: still advance even if the duration write fails.
+				}
+			}
+			await advance("completed");
+		},
+		[durationPrompt, updatePiece, advance],
+	);
+
+	const handleDurationSkip = useCallback(async () => {
+		setDurationPrompt(null);
+		await advance("completed");
+	}, [advance]);
 
 	const handleSkip = useCallback(async () => {
 		await advance("skipped");
@@ -305,7 +361,88 @@ export default function CoachScreen() {
 			>
 				{body}
 			</CoachShell>
+			<DurationPromptDialog
+				visible={!!durationPrompt}
+				title={durationPrompt?.title ?? ""}
+				elapsedSeconds={durationPrompt?.elapsedSeconds ?? 0}
+				onSave={handleDurationSave}
+				onSkip={handleDurationSkip}
+			/>
 		</CoachProvider>
+	);
+}
+
+function DurationPromptDialog({
+	visible,
+	title,
+	elapsedSeconds,
+	onSave,
+	onSkip,
+}: {
+	visible: boolean;
+	title: string;
+	elapsedSeconds: number;
+	onSave: (minutes: number) => void;
+	onSkip: () => void;
+}) {
+	const { t } = useTranslation();
+	const [minutesText, setMinutesText] = useState("");
+
+	useEffect(() => {
+		if (visible) {
+			setMinutesText(String(Math.max(1, Math.round(elapsedSeconds / 60))));
+		}
+	}, [visible, elapsedSeconds]);
+
+	const minutes = Number.parseInt(minutesText.trim(), 10);
+	const valid = !Number.isNaN(minutes) && minutes >= 1;
+
+	return (
+		<Portal>
+			<Dialog visible={visible} onDismiss={onSkip}>
+				<Dialog.Title>
+					{t("screen.session.coach.durationPrompt.title", { piece: title })}
+				</Dialog.Title>
+				<Dialog.Content>
+					<Text variant="bodyMedium">
+						{t("screen.session.coach.durationPrompt.measured", {
+							time: formatMMSS(elapsedSeconds),
+						})}
+					</Text>
+					<TextInput
+						label={t("screen.session.coach.durationPrompt.minutesLabel")}
+						value={minutesText}
+						onChangeText={setMinutesText}
+						mode="outlined"
+						keyboardType="numeric"
+						error={!valid}
+						style={{ marginTop: 12 }}
+					/>
+					<HelperText type="error" visible={!valid}>
+						{t("screen.session.coach.durationPrompt.invalid")}
+					</HelperText>
+				</Dialog.Content>
+				<Dialog.Actions>
+					<Button
+						onPress={onSkip}
+						accessibilityLabel={t(
+							"screen.session.coach.durationPrompt.skipA11y",
+						)}
+					>
+						{t("screen.session.coach.durationPrompt.skip")}
+					</Button>
+					<Button
+						onPress={() => onSave(minutes)}
+						disabled={!valid}
+						accessibilityLabel={t(
+							"screen.session.coach.durationPrompt.saveA11y",
+						)}
+					>
+						{t("screen.session.coach.durationPrompt.save")}
+					</Button>
+				</Dialog.Actions>
+			</Dialog>
+		</Portal>
 	);
 }
 

--- a/docs/specs/session-time-and-piece-durations.md
+++ b/docs/specs/session-time-and-piece-durations.md
@@ -1,0 +1,201 @@
+# Spec: Session Time & Piece Durations
+
+## Phase 0: Handoff
+
+**Spec file:** `docs/specs/session-time-and-piece-durations.md`
+
+**Implementer instructions:**
+
+- Use the **Phases** section (Phase 1–6) as the implementation plan. No separate PLAN.md needed.
+- Build phases in order — later phases depend on earlier ones (data model before planner before UI).
+- Run `yarn lint` and `yarn test` after each phase. Fix **all** issues, including pre-existing.
+- All new UI strings go through i18n (`i18n/locales`). No hardcoded strings. Add localized `accessibilityLabel`/`accessibilityHint` to any new icon-only controls.
+- Firestore: never write `undefined`. Optional fields that are unset must be `null`.
+- Manually test via Playwright (login `senth.wallace@gmail.com` / `hellomynameispassword123`, local server `http://localhost:8081`).
+- Never commit — the user reviews and commits manually.
+- Respond in caveman ultra.
+- After all phases verified working, check off these three items in `PLAN.md` (under **Phase 3: Practice Task Model & Logging → Misc**):
+  - `Add duration for pieces …`
+  - `When practicing maintenance pieces, it should pick many …`
+  - `Instead of carrying the session time forward … distributed "evenly" …`
+
+## 1. What
+
+Three improvements to the existing session generator/coach (`utils/session-planner.ts`, `app/(app)/session/*`):
+
+1. **Piece duration** — a `durationSeconds` field on pieces, set manually in the piece form or captured in-session (maintenance blocks only) from elapsed time. Feeds the maintenance planner.
+2. **Maintenance picks many pieces** — the maintenance allotment is packed with as many pieces as fit (one full play-through each + 20% buffer), each as its own coach block, instead of dumping all the minutes on a single piece.
+3. **Proportional time redistribution** — when a slot has no eligible content at plan-build time, its minutes are spread across the surviving blocks in proportion to their current allocation, instead of being dumped into one bucket.
+
+## 2. Why
+
+The maintenance block currently gives ~12 min to one piece — pedagogically wrong; maintenance means rotating many pieces, one clean run-through each. Durations let the planner fit the right number of pieces. Proportional redistribution keeps a session's intended shape when content is missing, rather than over-feeding whichever bucket happens to be first.
+
+## 3. Data Model
+
+### `models/piece.ts` — extend `Piece`
+
+```typescript
+export interface Piece {
+  // …existing…
+  durationSeconds?: number | null; // full play-through estimate; null if unknown
+}
+```
+
+- **No** `durationSource` field, **no** playthrough-count field (deferred).
+- `hooks/use-pieces.ts`:
+  - `FirestorePiece` interface: add `durationSeconds?: number | null`.
+  - `fromFirestore`: add `durationSeconds: data.durationSeconds ?? null`.
+  - `useAddPiece.addPiece(...)` takes **positional args** today `(title, composer, state, targetTempoBpm)` — extend it to accept `durationSeconds: number | null = null` and write it in the `addDoc` payload.
+  - `useUpdatePiece.updatePiece` uses a `Pick<Piece, …>` whitelist — **add `"durationSeconds"`** to it, or the update will be type-rejected.
+- Firestore never accepts `undefined`; pass `null` when unset.
+
+No other model changes. No new Firestore collections. Sessions stay ephemeral (AsyncStorage), as today.
+
+## 4. Planner Logic
+
+All in `utils/session-planner.ts`. `now`-injectable and deterministic, as the existing code is.
+
+### 4.1 Maintenance: pick many (replaces `pickRepertoireMaintenance`)
+
+New `pickRepertoireMaintenanceBlocks(pieces, budgetMinutes, now, usedPieceIds)` → `{ blocks: PlannedBlock[]; leftoverMinutes: number }`.
+
+- Pool: `eligibleMaintenancePieces` (state `maintenance` | `performance`, not practiced today, not already used) — unchanged.
+- Score & sort desc with existing formula (`days × stateWeight + bpmGap`), tie-break by title.
+- **Per-piece cost (minutes):**
+  - `piece.durationSeconds != null` → `max(1, Math.round((durationSeconds / 60) * 1.2))` (full play-through + 20% buffer).
+  - else → `5` (default; no buffer applied to the guess).
+- **Greedy packing:**
+  - Walk pieces best-score-first. `remaining = budgetMinutes`.
+  - **First (best) piece is always taken**, even if its cost exceeds `remaining` — allocate its **full cost** (the session may overrun; this guarantees long pieces still get maintained and that maintenance is never empty when eligible pieces exist). Then `remaining -= cost`.
+  - For each subsequent piece: take it **only if `cost <= remaining`**; allocate full cost; `remaining -= cost`. The first piece that does not fully fit → **stop**.
+  - `leftoverMinutes = max(0, remaining)`.
+- Each block: `{ kind: "repertoire-maintenance", pieceId, allocatedMinutes: cost, title, subtitle: composer, score }`.
+
+### 4.2 Leftover redistribution (maintenance)
+
+`leftoverMinutes` from 4.1 is added to the **learning** and **stabilizing** blocks in proportion to their current `allocatedMinutes`. If only one exists, it gets all of it. If neither exists, the leftover is dropped (session runs slightly shorter). Use last-gets-remainder so the integer sum is exact.
+
+### 4.3 Proportional empty-content redistribution (replaces `redistributeRepertoireForAvailability` **and** the technique-omit dump)
+
+One pass over these slots: `technique`, `sightReading`, `repertoireLearning`, `repertoireStabilizing`, `repertoireMaintenance`. **Warmup is excluded** (kept as-is with its freeform fallback; its minutes are never redistributed).
+
+- **Availability:**
+  - `technique` available ⇔ ≥1 eligible technique (`active`/`maintenance`, not practiced today).
+  - `sightReading` available ⇔ `alloc.sightReading > 0` (freeform timer — always runnable; needs no material).
+  - `repertoireLearning` / `repertoireStabilizing` available ⇔ ≥1 eligible section candidate for that slot.
+  - `repertoireMaintenance` available ⇔ ≥1 eligible maintenance piece.
+- For every slot with `allocation > 0` but **not** available: add its minutes to a `freed` pool and zero the slot.
+- Recipients = slots with `allocation > 0` **and** available. Distribute `freed` across recipients **proportional to their current (post-zeroing) allocation**. Integer split via last-gets-remainder so the total is conserved.
+- If there are no recipients, `freed` is dropped (shorter/empty session).
+- This is **build-time only**, for **empty content**. It does **not** change:
+  - User-disabled domain switches → those minutes still dump to repertoire in `allocateTime` (unchanged; intentional choice).
+  - Runtime **Skip** → still just ends the session earlier (no live redistribution).
+
+**Worked example (the user's):** total 30, `tech 10 / read 5 / rep 15`; a 5-min slot is freed and the three above are the recipients → `tech += (10/30)×5 = 1.67`, `read += (5/30)×5 = 0.83`, `rep += (15/30)×5 = 2.5`. (Integerized; sum preserved.)
+
+### 4.4 `buildPlan` order
+
+1. `alloc = allocateTime(inputs)` (disabled domains already folded into repertoire — unchanged).
+2. Compute availability flags (4.3).
+3. Apply proportional redistribution (4.3) → updated `technique / sightReading / learning / stabilizing / maintenance` minutes. Record `omitted[]` entries for zeroed slots (reason `practiced-today` vs `no-content`) — keep this; the setup preview uses it.
+4. Warmup block (unchanged).
+5. Technique blocks via `pickTechnique(updatedTechnique, …)`.
+6. Learning + stabilizing single blocks (updated minutes).
+7. Maintenance: `pickRepertoireMaintenanceBlocks(updatedMaintenance, …)` → multiple blocks + leftover.
+8. Apply 4.2 leftover bump to learning/stabilizing blocks.
+9. Sight-reading block (updated minutes).
+10. Assemble in `ORDER_BY_EMPHASIS`; the `repertoire-maintenance` slot now contributes the **array** of maintenance blocks (the `byKind` map already supports arrays — mirror the `technique` handling).
+
+## 5. UI Flow
+
+### 5.1 Piece form (`app/(app)/piece/add.tsx` + `app/(app)/piece/[id]/edit.tsx`)
+
+- Add an optional **Duration** field (numeric, **minutes**), placed near target BPM.
+- Save: `durationSeconds = minutes ? minutes * 60 : null`. Edit: prefill `Math.round(durationSeconds / 60)` when set, else blank.
+- Validate like other numeric inputs (positive integer, inline error on bad input).
+
+### 5.2 In-session duration prompt (coach) — **maintenance blocks only**
+
+In `app/(app)/session/coach.tsx`, when advancing via **Save & next** from a block where:
+`block.kind === "repertoire-maintenance"` **and** `block.pieceId` is set **and** that piece's `durationSeconds == null`
+
+→ show a dialog **before** advancing:
+
+```
+Set duration for {pieceTitle}?
+Measured: ~{mm:ss}        (block elapsed)
+[ {minutes} ] min         (editable; prefilled round(elapsedSeconds/60), min 1)
+[Skip]              [Save]
+```
+
+- **Save** → `updatePiece(pieceId, { durationSeconds: enteredMinutes * 60 })`, then advance.
+- **Skip** → advance, write nothing.
+- Read the piece's current `durationSeconds` via the cached `usePieces()` list (look up by `pieceId`).
+- Does **not** fire on Skip-block (no play-through happened) or on learning/stabilizing/whole-piece-without-sections blocks.
+
+### 5.3 Setup preview (`app/(app)/session/setup.tsx`)
+
+The live "Estimated plan" preview must render the maintenance slot as **multiple lines** (one per picked piece) or a count — reflecting the new multi-block maintenance output and any redistribution.
+
+### 5.4 Summary (`app/(app)/session/summary.tsx`)
+
+Already lists blocks; verify it renders multiple maintenance lines and that totals (practiced vs allotted, skipped count) remain correct with the larger block count and possible overrun.
+
+## 6. Logging
+
+- No new log types. Each maintenance piece is its **own** `repertoire-maintenance` block → its **own** `PiecePractice` entry via the existing `useSavePractice` (`triggeredFrom: "session-coach"`, no `sectionId`). This already happens once maintenance emits separate blocks.
+- `durationSeconds` written to the piece doc via `useUpdatePiece`.
+- No duration source, no playthrough count, no redistribution-event logging (all deferred).
+
+## 7. Out of Scope
+
+- `durationSource` (manual vs measured) tracking.
+- Playthrough-count input — assume 1 per maintenance piece.
+- Duration prompt on non-maintenance blocks (learning/stabilizing whole-piece).
+- Cross-day maintenance rotation cap (same-day repeat already blocked) — Phase 5.
+- Runtime-Skip live redistribution; per-domain ceilings on redistribution.
+- A future heuristic deciding **whether** to schedule maintenance at all (for now always pick ≥1 when eligible).
+- Redistribution-event logging; persisting sessions to Firestore (stay ephemeral).
+- m:ss input widget in the piece form (form uses whole minutes; in-session prompt shows measured as m:ss but edits minutes).
+
+## 8. Phases
+
+### Phase 1: Piece duration data model + form
+
+- Add `durationSeconds?: number | null` to `models/piece.ts`; map it in `hooks/use-pieces.ts` `toPiece`.
+- Add the optional Duration (minutes) field to `piece/add.tsx` and `piece/[id]/edit.tsx`; store `minutes * 60` or `null`; validate.
+- i18n keys for the label/helper/validation.
+- Tests: `toPiece` round-trip incl. null; form maps minutes↔seconds.
+
+### Phase 2: Maintenance picks many (planner)
+
+- Replace `pickRepertoireMaintenance` with `pickRepertoireMaintenanceBlocks` (§4.1): cost = `round(durationSeconds/60 × 1.2)` or `5`; greedy packing; first piece always taken (full cost even if over budget); stop on first non-fitting subsequent piece; return blocks + `leftoverMinutes`.
+- `buildPlan`: emit maintenance as an array; apply leftover bump to learning/stabilizing (§4.2).
+- Unit tests: single vs many; durations vs default-5; exact-fit; leftover→learning/stabilizing (and drop when neither); oversized first piece overruns; `usedPieceIds` no double-pick; deterministic order/tie-breaks.
+
+### Phase 3: Proportional empty-content redistribution (planner)
+
+- Implement §4.3 pass; delete `redistributeRepertoireForAvailability` and the technique-omit dump; keep `omitted[]` population.
+- Unit tests: the worked example (tech10/read5/rep15, freed 5); single empty slot; multiple empty slots; technique-empty spreads cross-domain; all-repertoire-empty; no-recipients drop; integer-sum conservation; disabled-switch behavior unchanged.
+
+### Phase 4: In-session duration prompt (coach)
+
+- §5.2 dialog wired into the Save & next advance path for maintenance blocks with null duration; `updatePiece` on Save; advance on Skip.
+- i18n keys; a11y labels on dialog buttons.
+
+### Phase 5: Setup preview + summary
+
+- §5.3 multi-piece maintenance preview; §5.4 summary verification with many maintenance blocks + overrun.
+- i18n keys for any new strings.
+
+### Phase 6: Lint, i18n, a11y, Playwright e2e
+
+- `yarn lint` + `yarn test` green (fix pre-existing too).
+- Playwright end-to-end:
+  - Set a piece duration in the form; reopen edit → persists.
+  - Maintenance with several eligible pieces → multiple maintenance blocks; minutes match durations×1.2 / 5-default; first piece taken even when oversized.
+  - Leftover redistributes into learning/stabilizing (preview + coach).
+  - Empty-content redistribution: no learning pieces → minutes spread proportionally (verify worked example sums).
+  - In-session prompt appears only on maintenance whole-piece blocks with no duration; Save writes `durationSeconds`; Skip writes nothing.
+  - Summary totals/skipped correct with the larger block count.

--- a/hooks/use-pieces.test.ts
+++ b/hooks/use-pieces.test.ts
@@ -1,0 +1,41 @@
+jest.mock("firebase/firestore", () => ({
+	addDoc: jest.fn(),
+	collection: jest.fn(),
+	deleteDoc: jest.fn(),
+	doc: jest.fn(),
+	getDocs: jest.fn(),
+	onSnapshot: jest.fn(),
+	query: jest.fn(),
+	updateDoc: jest.fn(),
+}));
+jest.mock("@/config/firebase", () => ({ db: {}, auth: {} }));
+jest.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({ user: null }),
+}));
+
+import { fromFirestore } from "./use-pieces";
+
+describe("fromFirestore durationSeconds mapping", () => {
+	it("maps a present durationSeconds through", () => {
+		const piece = fromFirestore(
+			"id1",
+			{ title: "A", composer: "C", durationSeconds: 240 },
+			"user1",
+		);
+		expect(piece.durationSeconds).toBe(240);
+	});
+
+	it("maps an explicit null durationSeconds to null", () => {
+		const piece = fromFirestore(
+			"id1",
+			{ title: "A", composer: "C", durationSeconds: null },
+			"user1",
+		);
+		expect(piece.durationSeconds).toBeNull();
+	});
+
+	it("defaults a missing durationSeconds to null", () => {
+		const piece = fromFirestore("id1", { title: "A", composer: "C" }, "user1");
+		expect(piece.durationSeconds).toBeNull();
+	});
+});

--- a/hooks/use-pieces.ts
+++ b/hooks/use-pieces.ts
@@ -28,9 +28,10 @@ interface FirestorePiece {
 	lastAchievedTempoBpm?: number | null;
 	sectionCount?: number;
 	notes?: string | null;
+	durationSeconds?: number | null;
 }
 
-function fromFirestore(
+export function fromFirestore(
 	id: string,
 	data: FirestorePiece,
 	userId: string,
@@ -50,6 +51,7 @@ function fromFirestore(
 		lastAchievedTempoBpm: data.lastAchievedTempoBpm ?? null,
 		sectionCount: data.sectionCount ?? 0,
 		notes: data.notes ?? null,
+		durationSeconds: data.durationSeconds ?? null,
 	};
 }
 
@@ -90,6 +92,7 @@ export function useAddPiece() {
 		composer: string,
 		state: PieceState = "learning",
 		targetTempoBpm: number | null = null,
+		durationSeconds: number | null = null,
 	) => {
 		if (!user) throw new Error("Not authenticated");
 
@@ -99,6 +102,7 @@ export function useAddPiece() {
 			composer,
 			state,
 			targetTempoBpm,
+			durationSeconds,
 			lastPracticed: null,
 		});
 	};
@@ -125,6 +129,7 @@ export function useUpdatePiece() {
 				| "lastMemoryMistakes"
 				| "lastAchievedTempoBpm"
 				| "notes"
+				| "durationSeconds"
 			>
 		>,
 	) => {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -111,6 +111,7 @@
 		"deleteSection": "Failed to archive section. Please try again.",
 		"reorderSections": "Failed to reorder sections. Please try again.",
 		"bpmInvalid": "Enter a BPM between 20 and 240.",
+		"durationInvalid": "Enter a duration between 1 and 600 minutes.",
 		"googleSignIn": "Google sign-in failed. Please try again."
 	},
 	"screen": {
@@ -191,6 +192,7 @@
 			"composerLabel": "Composer",
 			"stateLabel": "Lifecycle State",
 			"targetTempoBpmLabel": "Target Tempo (BPM)",
+			"durationLabel": "Duration (minutes)",
 			"save": "Save",
 			"error": {
 				"titleRequired": "Title is required.",
@@ -241,6 +243,7 @@
 			"stateLabel": "Lifecycle State",
 			"learningPhaseLabel": "Learning Phase",
 			"targetTempoBpmLabel": "Target Tempo (BPM)",
+			"durationLabel": "Duration (minutes)",
 			"difficultyLabel": "Difficulty",
 			"notesLabel": "Notes (optional)",
 			"save": "Save",
@@ -395,7 +398,17 @@
 				"extend": "Extend +2 min",
 				"sightReadingBody": "Sight-reading — pick your material",
 				"warmupBody": "Warmup — gentle scales of your choice",
-				"done": "Done"
+				"done": "Done",
+				"durationPrompt": {
+					"title": "Set duration for {{piece}}?",
+					"measured": "Measured: ~{{time}}",
+					"minutesLabel": "Minutes",
+					"invalid": "Enter at least 1 minute.",
+					"skip": "Skip",
+					"skipA11y": "Skip setting duration",
+					"save": "Save",
+					"saveA11y": "Save duration"
+				}
 			},
 			"resume": {
 				"banner": "Session in progress — {{emphasis}}, {{minutes}} min",

--- a/models/piece.ts
+++ b/models/piece.ts
@@ -45,4 +45,5 @@ export interface Piece {
 	lastAchievedTempoBpm?: number | null;
 	sectionCount?: number;
 	notes?: string | null;
+	durationSeconds?: number | null; // full play-through estimate; null if unknown
 }

--- a/utils/session-planner.test.ts
+++ b/utils/session-planner.test.ts
@@ -5,10 +5,13 @@ import type { TechniqueItem, TechniqueState } from "@/models/technique";
 import {
 	allocateTime,
 	buildPlan,
-	pickRepertoireMaintenance,
+	pickRepertoireMaintenanceBlocks,
 	pickRepertoireSection,
 	pickTechnique,
 	pickWarmup,
+	redistributeForAvailability,
+	type SlotAvailability,
+	type SlotMinutes,
 } from "./session-planner";
 
 function inputs(overrides: Partial<SessionInputs> = {}): SessionInputs {
@@ -328,8 +331,8 @@ describe("pickRepertoireSection", () => {
 	});
 });
 
-describe("pickRepertoireMaintenance", () => {
-	it("includes maintenance + performance pieces", () => {
+describe("pickRepertoireMaintenanceBlocks", () => {
+	it("includes maintenance + performance pieces, best first", () => {
 		const days = new Date(NOW.getTime() - 5 * 86400000);
 		const pieces: Piece[] = [
 			makePiece({
@@ -345,9 +348,9 @@ describe("pickRepertoireMaintenance", () => {
 				lastPracticed: days,
 			}),
 		];
-		const b = pickRepertoireMaintenance(pieces, 5, NOW);
+		const { blocks } = pickRepertoireMaintenanceBlocks(pieces, 5, NOW);
 		// performance × 3 weight beats maintenance × 1 with same staleness
-		expect(b?.pieceId).toBe("p2");
+		expect(blocks[0]?.pieceId).toBe("p2");
 	});
 
 	it("excludes on_hold and shelved", () => {
@@ -355,10 +358,16 @@ describe("pickRepertoireMaintenance", () => {
 			makePiece({ id: "p1", state: "on_hold" as PieceState }),
 			makePiece({ id: "p2", state: "shelved" as PieceState }),
 		];
-		expect(pickRepertoireMaintenance(pieces, 5, NOW)).toBeNull();
+		const { blocks, leftoverMinutes } = pickRepertoireMaintenanceBlocks(
+			pieces,
+			5,
+			NOW,
+		);
+		expect(blocks).toEqual([]);
+		expect(leftoverMinutes).toBe(5);
 	});
 
-	it("BPM gap influences score", () => {
+	it("BPM gap influences score ordering", () => {
 		const days = new Date(NOW.getTime() - 5 * 86400000);
 		const pieces: Piece[] = [
 			makePiece({
@@ -378,8 +387,231 @@ describe("pickRepertoireMaintenance", () => {
 				lastAchievedTempoBpm: 110,
 			}),
 		];
-		const b = pickRepertoireMaintenance(pieces, 5, NOW);
-		expect(b?.pieceId).toBe("p1");
+		const { blocks } = pickRepertoireMaintenanceBlocks(pieces, 5, NOW);
+		expect(blocks[0]?.pieceId).toBe("p1");
+	});
+
+	it("packs many pieces using duration × 1.2 cost", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			// 5 min play-through → cost round(5 × 1.2) = 6
+			makePiece({
+				id: "p1",
+				state: "maintenance",
+				title: "A",
+				lastPracticed: days,
+				durationSeconds: 300,
+			}),
+			// 5 min play-through → cost 6
+			makePiece({
+				id: "p2",
+				state: "maintenance",
+				title: "B",
+				lastPracticed: days,
+				durationSeconds: 300,
+			}),
+			// 5 min play-through → cost 6 (won't fit: 6 + 6 = 12 > 13? fits; third 6 > 1 → stop)
+			makePiece({
+				id: "p3",
+				state: "maintenance",
+				title: "C",
+				lastPracticed: days,
+				durationSeconds: 300,
+			}),
+		];
+		const { blocks, leftoverMinutes } = pickRepertoireMaintenanceBlocks(
+			pieces,
+			13,
+			NOW,
+		);
+		expect(blocks).toHaveLength(2);
+		expect(blocks.every((b) => b.allocatedMinutes === 6)).toBe(true);
+		expect(leftoverMinutes).toBe(1);
+	});
+
+	it("uses default 5-min cost when duration unknown", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({ id: "p1", state: "maintenance", lastPracticed: days }),
+			makePiece({ id: "p2", state: "maintenance", lastPracticed: days }),
+		];
+		const { blocks, leftoverMinutes } = pickRepertoireMaintenanceBlocks(
+			pieces,
+			12,
+			NOW,
+		);
+		expect(blocks).toHaveLength(2);
+		expect(blocks.every((b) => b.allocatedMinutes === 5)).toBe(true);
+		expect(leftoverMinutes).toBe(2);
+	});
+
+	it("always takes the first piece even when it overruns the budget", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({
+				id: "p1",
+				state: "maintenance",
+				lastPracticed: days,
+				durationSeconds: 1800, // 30 min → cost round(30 × 1.2) = 36
+			}),
+			makePiece({
+				id: "p2",
+				state: "maintenance",
+				lastPracticed: days,
+				durationSeconds: 300,
+			}),
+		];
+		const { blocks, leftoverMinutes } = pickRepertoireMaintenanceBlocks(
+			pieces,
+			5,
+			NOW,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].allocatedMinutes).toBe(36);
+		expect(leftoverMinutes).toBe(0);
+	});
+
+	it("respects usedPieceIds (no double-pick)", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({ id: "p1", state: "maintenance", lastPracticed: days }),
+			makePiece({ id: "p2", state: "maintenance", lastPracticed: days }),
+		];
+		const used = new Set<string>(["p1"]);
+		const { blocks } = pickRepertoireMaintenanceBlocks(pieces, 30, NOW, used);
+		expect(blocks.map((b) => b.pieceId)).toEqual(["p2"]);
+	});
+
+	it("exact-fit consumes the whole budget with no leftover", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({ id: "p1", state: "maintenance", lastPracticed: days }),
+			makePiece({ id: "p2", state: "maintenance", lastPracticed: days }),
+		];
+		const { blocks, leftoverMinutes } = pickRepertoireMaintenanceBlocks(
+			pieces,
+			10,
+			NOW,
+		);
+		expect(blocks).toHaveLength(2);
+		expect(leftoverMinutes).toBe(0);
+	});
+});
+
+describe("redistributeForAvailability", () => {
+	function alloc(over: Partial<SlotMinutes> = {}): SlotMinutes {
+		return {
+			technique: 0,
+			sightReading: 0,
+			repertoireLearning: 0,
+			repertoireStabilizing: 0,
+			repertoireMaintenance: 0,
+			...over,
+		};
+	}
+	function avail(over: Partial<SlotAvailability> = {}): SlotAvailability {
+		return {
+			technique: true,
+			sightReading: true,
+			repertoireLearning: true,
+			repertoireStabilizing: true,
+			repertoireMaintenance: true,
+			...over,
+		};
+	}
+
+	it("worked example: tech10/read5/rep15, 5 freed → 12/6/17, sum conserved", () => {
+		const a = alloc({
+			technique: 10,
+			sightReading: 5,
+			repertoireLearning: 15,
+			repertoireMaintenance: 5,
+		});
+		const v = avail({ repertoireMaintenance: false });
+		const r = redistributeForAvailability(a, v);
+		expect(r.technique).toBe(12);
+		expect(r.sightReading).toBe(6);
+		expect(r.repertoireLearning).toBe(17);
+		expect(r.repertoireMaintenance).toBe(0);
+		const total =
+			r.technique +
+			r.sightReading +
+			r.repertoireLearning +
+			r.repertoireStabilizing +
+			r.repertoireMaintenance;
+		expect(total).toBe(35);
+	});
+
+	it("single empty slot spreads across the rest", () => {
+		const a = alloc({ technique: 10, repertoireLearning: 10 });
+		const v = avail({ repertoireLearning: false });
+		const r = redistributeForAvailability(a, v);
+		expect(r.technique).toBe(20);
+		expect(r.repertoireLearning).toBe(0);
+	});
+
+	it("multiple empty slots pool together", () => {
+		const a = alloc({
+			technique: 4,
+			sightReading: 6,
+			repertoireLearning: 10,
+		});
+		const v = avail({ technique: false, sightReading: false });
+		const r = redistributeForAvailability(a, v);
+		expect(r.technique).toBe(0);
+		expect(r.sightReading).toBe(0);
+		expect(r.repertoireLearning).toBe(20);
+	});
+
+	it("technique-empty spreads cross-domain into repertoire + reading", () => {
+		const a = alloc({
+			technique: 6,
+			sightReading: 6,
+			repertoireLearning: 6,
+		});
+		const v = avail({ technique: false });
+		const r = redistributeForAvailability(a, v);
+		expect(r.technique).toBe(0);
+		// 6 freed split proportionally across read(6)+learning(6): 3 + 3
+		expect(r.sightReading).toBe(9);
+		expect(r.repertoireLearning).toBe(9);
+	});
+
+	it("all repertoire empty → minutes go to technique + reading", () => {
+		const a = alloc({
+			technique: 5,
+			sightReading: 5,
+			repertoireLearning: 5,
+			repertoireStabilizing: 5,
+		});
+		const v = avail({
+			repertoireLearning: false,
+			repertoireStabilizing: false,
+		});
+		const r = redistributeForAvailability(a, v);
+		expect(r.repertoireLearning).toBe(0);
+		expect(r.repertoireStabilizing).toBe(0);
+		expect(r.technique + r.sightReading).toBe(20);
+	});
+
+	it("no recipients → freed minutes dropped", () => {
+		const a = alloc({ technique: 10 });
+		const v = avail({ technique: false });
+		const r = redistributeForAvailability(a, v);
+		expect(r.technique).toBe(0);
+		const total =
+			r.technique +
+			r.sightReading +
+			r.repertoireLearning +
+			r.repertoireStabilizing +
+			r.repertoireMaintenance;
+		expect(total).toBe(0);
+	});
+
+	it("no change when everything is available", () => {
+		const a = alloc({ technique: 7, sightReading: 4, repertoireLearning: 19 });
+		const r = redistributeForAvailability(a, avail());
+		expect(r).toEqual(a);
 	});
 });
 
@@ -727,6 +959,91 @@ describe("buildPlan", () => {
 		expect(plan2Piece?.pieceId).toBe("p2"); // p2 wins (8 days stale > 1 day)
 		expect(plan2Tech?.techniqueId).toBe("t2"); // t2 wins (8 days stale > 1 day)
 	});
+
+	it("emits multiple maintenance blocks packed by duration", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({ id: "p1", state: "learning" }),
+			...["m1", "m2", "m3", "m4"].map((id) =>
+				makePiece({
+					id,
+					title: id.toUpperCase(),
+					state: "maintenance",
+					lastPracticed: days,
+					durationSeconds: 60, // cost round(1 × 1.2) = 1
+				}),
+			),
+		];
+		const ts: TechniqueItem[] = [makeTechnique({ id: "a1", state: "active" })];
+		const plan = buildPlan(inputs({ totalMinutes: 60 }), pieces, [], ts, NOW);
+		const maint = plan.blocks.filter(
+			(b) => b.kind === "repertoire-maintenance",
+		);
+		expect(maint.length).toBeGreaterThanOrEqual(2);
+		expect(maint.every((b) => b.allocatedMinutes === 1)).toBe(true);
+	});
+
+	it("maintenance leftover bumps learning + stabilizing blocks", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({ id: "pl", state: "learning" }),
+			makePiece({ id: "ps", state: "stabilizing" }),
+			makePiece({
+				id: "pm",
+				state: "maintenance",
+				lastPracticed: days,
+				durationSeconds: 60, // cost 1 → leftover 4 of a 5-min maintenance budget
+			}),
+		];
+		const ts: TechniqueItem[] = [makeTechnique({ id: "a1", state: "active" })];
+		const plan = buildPlan(inputs({ totalMinutes: 60 }), pieces, [], ts, NOW);
+		const learn = plan.blocks.find((b) => b.kind === "repertoire-learning");
+		const stab = plan.blocks.find((b) => b.kind === "repertoire-stabilizing");
+		// base 19/11 + leftover 4 split proportionally (3 to learning, 1 to stabilizing)
+		expect(learn?.allocatedMinutes).toBe(22);
+		expect(stab?.allocatedMinutes).toBe(12);
+	});
+
+	it("drops maintenance leftover when no learning/stabilizing blocks exist", () => {
+		const days = new Date(NOW.getTime() - 5 * 86400000);
+		const pieces: Piece[] = [
+			makePiece({
+				id: "m1",
+				state: "maintenance",
+				lastPracticed: days,
+				durationSeconds: 60,
+			}),
+			makePiece({
+				id: "m2",
+				state: "maintenance",
+				lastPracticed: days,
+				durationSeconds: 60,
+			}),
+		];
+		const plan = buildPlan(
+			inputs({ totalMinutes: 30, emphasis: "repertoire-only" }),
+			pieces,
+			[],
+			[],
+			NOW,
+		);
+		expect(
+			plan.blocks.find((b) => b.kind === "repertoire-learning"),
+		).toBeUndefined();
+		expect(
+			plan.blocks.find((b) => b.kind === "repertoire-stabilizing"),
+		).toBeUndefined();
+		const maint = plan.blocks.filter(
+			(b) => b.kind === "repertoire-maintenance",
+		);
+		expect(maint.length).toBeGreaterThanOrEqual(1);
+		// Leftover dropped → session runs short (2 pieces × 1 min ≪ 30).
+		const totalAllocated = plan.blocks.reduce(
+			(acc, b) => acc + b.allocatedMinutes,
+			0,
+		);
+		expect(totalAllocated).toBeLessThan(30);
+	});
 });
 
 describe("same-day exclusion", () => {
@@ -784,8 +1101,8 @@ describe("same-day exclusion", () => {
 				lastPracticed: twoDaysAgo(),
 			}),
 		];
-		const block = pickRepertoireMaintenance(pieces, 5, NOW_LOCAL);
-		expect(block?.pieceId).toBe("p2");
+		const { blocks } = pickRepertoireMaintenanceBlocks(pieces, 5, NOW_LOCAL);
+		expect(blocks[0]?.pieceId).toBe("p2");
 	});
 
 	it("excludes technique practiced earlier today", () => {

--- a/utils/session-planner.ts
+++ b/utils/session-planner.ts
@@ -355,14 +355,36 @@ function eligibleMaintenancePieces(
 	);
 }
 
-export function pickRepertoireMaintenance(
+// Per-piece maintenance cost in minutes: a full play-through + 20% buffer when
+// a duration is known, otherwise a flat 5-minute guess (no buffer).
+function maintenanceCost(piece: Piece): number {
+	if (piece.durationSeconds != null) {
+		return Math.max(1, Math.round((piece.durationSeconds / 60) * 1.2));
+	}
+	return 5;
+}
+
+export interface MaintenancePackResult {
+	blocks: PlannedBlock[];
+	leftoverMinutes: number;
+}
+
+/**
+ * Packs as many maintenance pieces as fit into the budget, best-score-first,
+ * one block per piece. The best piece is always taken (even if it overruns the
+ * budget) so maintenance is never empty when eligible pieces exist; subsequent
+ * pieces are taken only while they fully fit, stopping at the first that does not.
+ */
+export function pickRepertoireMaintenanceBlocks(
 	pieces: Piece[],
-	allocatedMinutes: number,
+	budgetMinutes: number,
 	now: Date = new Date(),
 	usedPieceIds?: Set<string>,
-): PlannedBlock | null {
+): MaintenancePackResult {
 	const pool = eligibleMaintenancePieces(pieces, now, usedPieceIds);
-	if (pool.length === 0) return null;
+	if (pool.length === 0) {
+		return { blocks: [], leftoverMinutes: Math.max(0, budgetMinutes) };
+	}
 	const scored = pool.map((piece) => {
 		const stateWeight = piece.state === "performance" ? 3 : 1;
 		const days = daysSince(piece.lastPracticed ?? null, now);
@@ -376,16 +398,27 @@ export function pickRepertoireMaintenance(
 		if (b.score !== a.score) return b.score - a.score;
 		return compareTitle(a.piece.title, b.piece.title);
 	});
-	const best = scored[0];
-	return {
-		kind: "repertoire-maintenance",
-		allocatedMinutes,
-		pieceId: best.piece.id ?? null,
-		sectionId: null,
-		title: best.piece.title,
-		subtitle: best.piece.composer,
-		score: best.score,
-	};
+
+	const blocks: PlannedBlock[] = [];
+	let remaining = budgetMinutes;
+	for (let i = 0; i < scored.length; i++) {
+		const { piece, score } = scored[i];
+		const cost = maintenanceCost(piece);
+		// First (best) piece is always taken at full cost, even if it overruns.
+		// Any later piece is taken only if it fully fits; otherwise stop.
+		if (i > 0 && cost > remaining) break;
+		blocks.push({
+			kind: "repertoire-maintenance",
+			allocatedMinutes: cost,
+			pieceId: piece.id ?? null,
+			sectionId: null,
+			title: piece.title,
+			subtitle: piece.composer,
+			score,
+		});
+		remaining -= cost;
+	}
+	return { blocks, leftoverMinutes: Math.max(0, remaining) };
 }
 
 interface TechniqueScored {
@@ -555,108 +588,95 @@ export function pickWarmup(
 	};
 }
 
-function redistributeRepertoireForAvailability(
-	alloc: AllocationResult,
-	hasLearning: boolean,
-	hasStabilizing: boolean,
-	hasMaintenance: boolean,
-): { learning: number; stabilizing: number; maintenance: number } {
-	let l = alloc.repertoireLearning;
-	let s = alloc.repertoireStabilizing;
-	let m = alloc.repertoireMaintenance;
+export const REDISTRIBUTABLE_SLOTS = [
+	"technique",
+	"sightReading",
+	"repertoireLearning",
+	"repertoireStabilizing",
+	"repertoireMaintenance",
+] as const;
 
-	const adjust = (
-		excess: number,
-		targets: {
-			hasIt: boolean;
-			baseWeight: number;
-			setter: (v: number) => void;
-			current: number;
-		}[],
-	) => {
-		const eligible = targets.filter((t) => t.hasIt);
-		const totalWeight = eligible.reduce((acc, t) => acc + t.baseWeight, 0);
-		if (eligible.length === 0 || totalWeight <= 0) return;
-		let used = 0;
-		for (let i = 0; i < eligible.length; i++) {
-			const isLast = i === eligible.length - 1;
-			const target = eligible[i];
-			const portion = isLast
-				? excess - used
-				: Math.round((excess * target.baseWeight) / totalWeight);
-			target.setter(target.current + portion);
-			target.current += portion;
-			used += portion;
+export type RedistributableSlot = (typeof REDISTRIBUTABLE_SLOTS)[number];
+
+export type SlotMinutes = Record<RedistributableSlot, number>;
+export type SlotAvailability = Record<RedistributableSlot, boolean>;
+
+/**
+ * Build-time, empty-content redistribution. Every slot that has minutes but no
+ * eligible content is zeroed and its minutes pooled, then spread across the
+ * surviving (available) slots in proportion to their current allocation.
+ * Integer split via last-gets-remainder so the total is conserved. Warmup is
+ * never part of this and is handled separately.
+ */
+export function redistributeForAvailability(
+	alloc: SlotMinutes,
+	available: SlotAvailability,
+): SlotMinutes {
+	const result: SlotMinutes = { ...alloc };
+	let freed = 0;
+	for (const slot of REDISTRIBUTABLE_SLOTS) {
+		if (result[slot] > 0 && !available[slot]) {
+			freed += result[slot];
+			result[slot] = 0;
 		}
-	};
+	}
+	if (freed <= 0) return result;
 
-	if (!hasLearning && l > 0) {
-		const moveable = l;
-		l = 0;
-		adjust(moveable, [
-			{
-				hasIt: hasStabilizing,
-				baseWeight: 30,
-				current: s,
-				setter: (v) => {
-					s = v;
-				},
-			},
-			{
-				hasIt: hasMaintenance,
-				baseWeight: 15,
-				current: m,
-				setter: (v) => {
-					m = v;
-				},
-			},
-		]);
+	const recipients = REDISTRIBUTABLE_SLOTS.filter(
+		(slot) => result[slot] > 0 && available[slot],
+	);
+	if (recipients.length === 0) return result; // nothing to receive → dropped
+
+	const totalAlloc = recipients.reduce((acc, slot) => acc + result[slot], 0);
+	let used = 0;
+	for (let i = 0; i < recipients.length; i++) {
+		const slot = recipients[i];
+		const isLast = i === recipients.length - 1;
+		const portion = isLast
+			? freed - used
+			: Math.round((freed * result[slot]) / totalAlloc);
+		result[slot] += portion;
+		used += portion;
 	}
-	if (!hasStabilizing && s > 0) {
-		const moveable = s;
-		s = 0;
-		adjust(moveable, [
-			{
-				hasIt: hasLearning,
-				baseWeight: 55,
-				current: l,
-				setter: (v) => {
-					l = v;
-				},
-			},
-			{
-				hasIt: hasMaintenance,
-				baseWeight: 15,
-				current: m,
-				setter: (v) => {
-					m = v;
-				},
-			},
-		]);
+	return result;
+}
+
+/**
+ * Add maintenance leftover minutes to the learning/stabilizing blocks in
+ * proportion to their current allocation (last-gets-remainder). Mutates blocks
+ * in place. Dropped if neither block exists.
+ */
+function applyMaintenanceLeftover(
+	leftoverMinutes: number,
+	learningBlock: PlannedBlock | null,
+	stabilizingBlock: PlannedBlock | null,
+): void {
+	if (leftoverMinutes <= 0) return;
+	const recipients = [learningBlock, stabilizingBlock].filter(
+		(b): b is PlannedBlock => b != null,
+	);
+	if (recipients.length === 0) return;
+	const totalAlloc = recipients.reduce((acc, b) => acc + b.allocatedMinutes, 0);
+	let used = 0;
+	for (let i = 0; i < recipients.length; i++) {
+		const isLast = i === recipients.length - 1;
+		const portion = isLast
+			? leftoverMinutes - used
+			: totalAlloc > 0
+				? Math.round(
+						(leftoverMinutes * recipients[i].allocatedMinutes) / totalAlloc,
+					)
+				: Math.round(leftoverMinutes / recipients.length);
+		recipients[i].allocatedMinutes += portion;
+		used += portion;
 	}
-	if (!hasMaintenance && m > 0) {
-		const moveable = m;
-		m = 0;
-		adjust(moveable, [
-			{
-				hasIt: hasLearning,
-				baseWeight: 55,
-				current: l,
-				setter: (v) => {
-					l = v;
-				},
-			},
-			{
-				hasIt: hasStabilizing,
-				baseWeight: 30,
-				current: s,
-				setter: (v) => {
-					s = v;
-				},
-			},
-		]);
-	}
-	return { learning: l, stabilizing: s, maintenance: m };
+}
+
+function hasEligibleTechnique(techniques: TechniqueItem[], now: Date): boolean {
+	return (
+		eligibleTechniquesInState(techniques, "active", now).length > 0 ||
+		eligibleTechniquesInState(techniques, "maintenance", now).length > 0
+	);
 }
 
 function hasPiecesInState(pieces: Piece[], state: Piece["state"]): boolean {
@@ -681,16 +701,74 @@ export function buildPlan(
 	now: Date = new Date(),
 ): SessionPlan {
 	const alloc = allocateTime(inputs);
-	const usedTechniqueIds = new Set<string>();
 	const omitted: OmittedSlot[] = [];
 
+	// Availability flags (warmup excluded — it has its own freeform fallback).
+	const techniqueEligible = hasEligibleTechnique(techniques, now);
+	const learningEligible =
+		eligibleSectionCandidates("learning", pieces, sections, now).length > 0;
+	const stabilizingEligible =
+		eligibleSectionCandidates("stabilizing", pieces, sections, now).length > 0;
+	const maintenanceEligible = eligibleMaintenancePieces(pieces, now).length > 0;
+
+	const baseAlloc: SlotMinutes = {
+		technique: alloc.technique,
+		sightReading: alloc.sightReading,
+		repertoireLearning: alloc.repertoireLearning,
+		repertoireStabilizing: alloc.repertoireStabilizing,
+		repertoireMaintenance: alloc.repertoireMaintenance,
+	};
+	const available: SlotAvailability = {
+		technique: techniqueEligible,
+		// Sight-reading is a freeform timer — always runnable when it has minutes.
+		sightReading: alloc.sightReading > 0,
+		repertoireLearning: learningEligible,
+		repertoireStabilizing: stabilizingEligible,
+		repertoireMaintenance: maintenanceEligible,
+	};
+
+	// Record omitted entries for slots that get zeroed (the setup preview uses them).
+	if (baseAlloc.technique > 0 && !available.technique) {
+		omitted.push({
+			kind: "technique",
+			reason: omittedReason(hasAnyTechniqueInPool(techniques)),
+			redistributedMinutes: baseAlloc.technique,
+		});
+	}
+	if (baseAlloc.repertoireLearning > 0 && !available.repertoireLearning) {
+		omitted.push({
+			kind: "repertoire-learning",
+			reason: omittedReason(hasPiecesInState(pieces, "learning")),
+			redistributedMinutes: baseAlloc.repertoireLearning,
+		});
+	}
+	if (baseAlloc.repertoireStabilizing > 0 && !available.repertoireStabilizing) {
+		omitted.push({
+			kind: "repertoire-stabilizing",
+			reason: omittedReason(hasPiecesInState(pieces, "stabilizing")),
+			redistributedMinutes: baseAlloc.repertoireStabilizing,
+		});
+	}
+	if (baseAlloc.repertoireMaintenance > 0 && !available.repertoireMaintenance) {
+		omitted.push({
+			kind: "repertoire-maintenance",
+			reason: omittedReason(
+				hasPiecesInState(pieces, "maintenance") ||
+					hasPiecesInState(pieces, "performance"),
+			),
+			redistributedMinutes: baseAlloc.repertoireMaintenance,
+		});
+	}
+
+	const updated = redistributeForAvailability(baseAlloc, available);
+
+	const usedTechniqueIds = new Set<string>();
 	const warmupBlock: PlannedBlock | null =
 		alloc.warmup > 0 ? pickWarmup(techniques, alloc.warmup, now) : null;
 	if (warmupBlock?.techniqueId) usedTechniqueIds.add(warmupBlock.techniqueId);
 
-	let techMinutes = alloc.technique;
 	const techBlocks = pickTechnique(
-		techMinutes,
+		updated.technique,
 		techniques,
 		now,
 		usedTechniqueIds,
@@ -699,71 +777,16 @@ export function buildPlan(
 		if (tb.techniqueId) usedTechniqueIds.add(tb.techniqueId);
 	}
 
-	const hasLearningEligible =
-		eligibleSectionCandidates("learning", pieces, sections, now).length > 0;
-	const hasStabilizingEligible =
-		eligibleSectionCandidates("stabilizing", pieces, sections, now).length > 0;
-	const hasMaintenanceEligible =
-		eligibleMaintenancePieces(pieces, now).length > 0;
-
-	const repSplit = redistributeRepertoireForAvailability(
-		alloc,
-		hasLearningEligible,
-		hasStabilizingEligible,
-		hasMaintenanceEligible,
-	);
-
-	if (techMinutes > 0 && techBlocks.length === 0) {
-		omitted.push({
-			kind: "technique",
-			reason: omittedReason(hasAnyTechniqueInPool(techniques)),
-			redistributedMinutes: techMinutes,
-		});
-		if (hasLearningEligible) {
-			repSplit.learning += techMinutes;
-		} else if (hasStabilizingEligible) {
-			repSplit.stabilizing += techMinutes;
-		} else if (hasMaintenanceEligible) {
-			repSplit.maintenance += techMinutes;
-		}
-		techMinutes = 0;
-	}
-
-	if (alloc.repertoireLearning > 0 && !hasLearningEligible) {
-		omitted.push({
-			kind: "repertoire-learning",
-			reason: omittedReason(hasPiecesInState(pieces, "learning")),
-			redistributedMinutes: alloc.repertoireLearning,
-		});
-	}
-	if (alloc.repertoireStabilizing > 0 && !hasStabilizingEligible) {
-		omitted.push({
-			kind: "repertoire-stabilizing",
-			reason: omittedReason(hasPiecesInState(pieces, "stabilizing")),
-			redistributedMinutes: alloc.repertoireStabilizing,
-		});
-	}
-	if (alloc.repertoireMaintenance > 0 && !hasMaintenanceEligible) {
-		const rawMaintenance =
-			hasPiecesInState(pieces, "maintenance") ||
-			hasPiecesInState(pieces, "performance");
-		omitted.push({
-			kind: "repertoire-maintenance",
-			reason: omittedReason(rawMaintenance),
-			redistributedMinutes: alloc.repertoireMaintenance,
-		});
-	}
-
 	const usedSectionIds = new Set<string>();
 	const usedPieceIds = new Set<string>();
 
 	const learningBlock =
-		repSplit.learning > 0
+		updated.repertoireLearning > 0
 			? pickRepertoireSection(
 					"learning",
 					pieces,
 					sections,
-					repSplit.learning,
+					updated.repertoireLearning,
 					now,
 					usedSectionIds,
 				)
@@ -772,12 +795,12 @@ export function buildPlan(
 	if (learningBlock?.pieceId) usedPieceIds.add(learningBlock.pieceId);
 
 	const stabilizingBlock =
-		repSplit.stabilizing > 0
+		updated.repertoireStabilizing > 0
 			? pickRepertoireSection(
 					"stabilizing",
 					pieces,
 					sections,
-					repSplit.stabilizing,
+					updated.repertoireStabilizing,
 					now,
 					usedSectionIds,
 				)
@@ -786,21 +809,26 @@ export function buildPlan(
 		usedSectionIds.add(stabilizingBlock.sectionId);
 	if (stabilizingBlock?.pieceId) usedPieceIds.add(stabilizingBlock.pieceId);
 
-	const maintenanceBlock =
-		repSplit.maintenance > 0
-			? pickRepertoireMaintenance(
+	const { blocks: maintenanceBlocks, leftoverMinutes } =
+		updated.repertoireMaintenance > 0
+			? pickRepertoireMaintenanceBlocks(
 					pieces,
-					repSplit.maintenance,
+					updated.repertoireMaintenance,
 					now,
 					usedPieceIds,
 				)
-			: null;
+			: { blocks: [] as PlannedBlock[], leftoverMinutes: 0 };
+	for (const mb of maintenanceBlocks) {
+		if (mb.pieceId) usedPieceIds.add(mb.pieceId);
+	}
+
+	applyMaintenanceLeftover(leftoverMinutes, learningBlock, stabilizingBlock);
 
 	const sightBlock: PlannedBlock | null =
-		alloc.sightReading > 0
+		updated.sightReading > 0
 			? {
 					kind: "sight-reading",
-					allocatedMinutes: alloc.sightReading,
+					allocatedMinutes: updated.sightReading,
 					title: null,
 					subtitle: null,
 				}
@@ -812,7 +840,8 @@ export function buildPlan(
 		"sight-reading": sightBlock ?? undefined,
 		"repertoire-learning": learningBlock ?? undefined,
 		"repertoire-stabilizing": stabilizingBlock ?? undefined,
-		"repertoire-maintenance": maintenanceBlock ?? undefined,
+		"repertoire-maintenance":
+			maintenanceBlocks.length > 0 ? maintenanceBlocks : undefined,
 	};
 
 	const order = ORDER_BY_EMPHASIS[inputs.emphasis];


### PR DESCRIPTION
…bution

- Add optional durationSeconds to pieces (form field in minutes; stored as seconds, null when unset) feeding the session planner.
- Maintenance slot now packs as many pieces as fit (one play-through + 20% buffer each, or a 5-min default), one coach block per piece, instead of dumping all minutes on one piece. Leftover bumps learning/stabilizing.
- Replace availability redistribution with a single proportional pass: empty slots are zeroed and their minutes spread across surviving slots in proportion to their allocation (integer-conserving).
- In-session coach prompt (maintenance whole-piece blocks with no duration) captures the elapsed play-through as the piece duration on Save & next.
- New planner unit tests + fromFirestore round-trip; all strings i18n'd.