### PR TITLE
fix(practice): pause practice sessions

### DIFF
--- a/app/(app)/session/coach.tsx
+++ b/app/(app)/session/coach.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { type CoachContextValue, CoachProvider } from "@/contexts/CoachContext";
 import { useActiveSession } from "@/hooks/use-active-session";
 import { usePieces, useUpdatePiece } from "@/hooks/use-pieces";
+import { useSessionPause } from "@/hooks/use-session-pause";
 import type {
 	ActiveSession,
 	BlockExecutionState,
@@ -82,6 +83,10 @@ export default function CoachScreen() {
 		},
 		[user],
 	);
+
+	// Pause the timers when the user leaves the coach and resume on return:
+	// total continues from where it left off, current block resets to 0:00.
+	useSessionPause({ session, setSession, persist, loaded });
 
 	const currentBlock: PlannedBlock | null = useMemo(() => {
 		if (!session) return null;

--- a/hooks/use-session-pause.ts
+++ b/hooks/use-session-pause.ts
@@ -1,0 +1,87 @@
+import { useFocusEffect } from "expo-router";
+import { useCallback, useEffect, useRef } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import type { ActiveSession } from "@/models/session";
+import { pauseSession, resumeSession } from "@/utils/session-timing";
+
+interface UseSessionPauseArgs {
+	session: ActiveSession | null;
+	setSession: (session: ActiveSession) => void;
+	persist: (session: ActiveSession) => Promise<void>;
+	loaded: boolean;
+}
+
+/**
+ * Pauses the practice timer whenever the user leaves the coach screen — by
+ * navigating away, backgrounding the app, or hiding the browser tab — and
+ * resumes it on return. On resume the session total continues from where it
+ * left off while the current block timer resets to 0. See
+ * {@link pauseSession}/{@link resumeSession} for the re-anchor math.
+ */
+export function useSessionPause({
+	session,
+	setSession,
+	persist,
+	loaded,
+}: UseSessionPauseArgs): void {
+	const sessionRef = useRef(session);
+	sessionRef.current = session;
+	const mountedRef = useRef(true);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+
+	const commit = useCallback(
+		(next: ActiveSession, updateState: boolean) => {
+			sessionRef.current = next;
+			// Storage is the source of truth for the next mount; always persist.
+			void persist(next);
+			// Only resume updates the visible UI — pause happens while leaving/hidden.
+			if (updateState && mountedRef.current) setSession(next);
+		},
+		[persist, setSession],
+	);
+
+	const pause = useCallback(() => {
+		const current = sessionRef.current;
+		if (!current) return;
+		const next = pauseSession(current, new Date().toISOString());
+		if (next !== current) commit(next, false);
+	}, [commit]);
+
+	const resume = useCallback(() => {
+		const current = sessionRef.current;
+		if (!current) return;
+		const next = resumeSession(current, new Date().toISOString());
+		if (next !== current) commit(next, true);
+	}, [commit]);
+
+	// Resume on (re)focus, pause on blur / unmount (covers navigate-away).
+	useFocusEffect(
+		useCallback(() => {
+			resume();
+			return () => {
+				pause();
+			};
+		}, [resume, pause]),
+	);
+
+	// Pause/resume on app background/foreground while the screen stays mounted.
+	useEffect(() => {
+		const sub = AppState.addEventListener("change", (state: AppStateStatus) => {
+			if (state === "active") resume();
+			else if (state === "background") pause();
+		});
+		return () => sub.remove();
+	}, [resume, pause]);
+
+	// Cold start / fresh mount: re-anchor once the persisted session has loaded
+	// (e.g. reopened directly into the coach, or via the Overview "Resume" banner).
+	useEffect(() => {
+		if (loaded) resume();
+	}, [loaded, resume]);
+}

--- a/models/session.ts
+++ b/models/session.ts
@@ -72,4 +72,6 @@ export interface ActiveSession {
 	blockStates: BlockExecutionState[];
 	sessionElapsedSeconds: number;
 	currentBlockStartedAt?: string | null;
+	/** ISO timestamp set when the user leaves the coach, cleared on resume. */
+	pausedAt?: string | null;
 }

--- a/utils/session-timing.test.ts
+++ b/utils/session-timing.test.ts
@@ -1,0 +1,94 @@
+import type { ActiveSession } from "@/models/session";
+import { pauseSession, resumeSession } from "./session-timing";
+
+function baseSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+	return {
+		plan: {
+			emphasis: "balanced",
+			totalMinutes: 30,
+			blocks: [],
+			generatedAt: "2026-06-27T10:00:00.000Z",
+		},
+		inputs: {
+			emphasis: "balanced",
+			totalMinutes: 30,
+			techniqueEnabled: true,
+			sightReadingEnabled: true,
+		},
+		startedAt: "2026-06-27T10:00:00.000Z",
+		sessionId: "test-session-id",
+		currentBlockIndex: 2,
+		blockStates: [],
+		sessionElapsedSeconds: 0,
+		currentBlockStartedAt: "2026-06-27T10:09:00.000Z",
+		...overrides,
+	};
+}
+
+// Mirrors coach.tsx's diffSec for asserting displayed elapsed seconds.
+function elapsedAt(fromIso: string | null | undefined, nowIso: string): number {
+	if (!fromIso) return 0;
+	const t = new Date(fromIso).getTime();
+	if (Number.isNaN(t)) return 0;
+	return Math.max(0, Math.floor((new Date(nowIso).getTime() - t) / 1000));
+}
+
+describe("pauseSession", () => {
+	it("stamps pausedAt", () => {
+		const session = baseSession();
+		const paused = pauseSession(session, "2026-06-27T10:10:00.000Z");
+		expect(paused.pausedAt).toBe("2026-06-27T10:10:00.000Z");
+		expect(paused.startedAt).toBe(session.startedAt);
+		expect(paused.currentBlockStartedAt).toBe(session.currentBlockStartedAt);
+	});
+
+	it("is a no-op when already paused", () => {
+		const session = baseSession({ pausedAt: "2026-06-27T10:05:00.000Z" });
+		expect(pauseSession(session, "2026-06-27T10:10:00.000Z")).toBe(session);
+	});
+
+	it("is a no-op for a finished session (no in-progress block)", () => {
+		const session = baseSession({ currentBlockStartedAt: null });
+		expect(pauseSession(session, "2026-06-27T10:10:00.000Z")).toBe(session);
+	});
+});
+
+describe("resumeSession", () => {
+	it("is a no-op when not paused", () => {
+		const session = baseSession();
+		expect(resumeSession(session, "2026-06-27T13:10:00.000Z")).toBe(session);
+	});
+
+	it("freezes the session total across the gap and resets the block to 0", () => {
+		// Issue #53 example: 10:00 total, 1:00 into the block, then away 3 hours.
+		const pausedAt = "2026-06-27T10:10:00.000Z"; // 600s total at pause
+		const now = "2026-06-27T13:10:00.000Z"; // resumed 3h later
+		const session = pauseSession(baseSession(), pausedAt);
+
+		const resumed = resumeSession(session, now);
+
+		// Total continues from 600s (not inflated by the 3h away).
+		expect(elapsedAt(resumed.startedAt, now)).toBe(600);
+		// Current block resets to 0:00.
+		expect(resumed.currentBlockStartedAt).toBe(now);
+		expect(elapsedAt(resumed.currentBlockStartedAt, now)).toBe(0);
+		expect(resumed.pausedAt).toBeNull();
+	});
+
+	it("keeps the total counting forward after resume", () => {
+		const session = pauseSession(baseSession(), "2026-06-27T10:10:00.000Z");
+		const resumed = resumeSession(session, "2026-06-27T13:10:00.000Z");
+		// 30s after resume → total 630s, block 30s.
+		const later = "2026-06-27T13:10:30.000Z";
+		expect(elapsedAt(resumed.startedAt, later)).toBe(630);
+		expect(elapsedAt(resumed.currentBlockStartedAt, later)).toBe(30);
+	});
+
+	it("falls back to resetting the block when timestamps are unparseable", () => {
+		const session = baseSession({ pausedAt: "not-a-date" });
+		const resumed = resumeSession(session, "2026-06-27T13:10:00.000Z");
+		expect(resumed.startedAt).toBe(session.startedAt);
+		expect(resumed.currentBlockStartedAt).toBe("2026-06-27T13:10:00.000Z");
+		expect(resumed.pausedAt).toBeNull();
+	});
+});

--- a/utils/session-timing.ts
+++ b/utils/session-timing.ts
@@ -1,0 +1,50 @@
+import type { ActiveSession } from "@/models/session";
+
+function parseTime(iso: string | null | undefined): number | null {
+	if (!iso) return null;
+	const t = new Date(iso).getTime();
+	return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Marks the session as paused at `nowIso`. No-op (returns the same reference)
+ * when the session is already paused or has no in-progress block — e.g. it has
+ * finished and is on its way to the summary, which must keep its final timing.
+ */
+export function pauseSession(
+	session: ActiveSession,
+	nowIso: string,
+): ActiveSession {
+	if (session.pausedAt) return session;
+	if (!session.currentBlockStartedAt) return session;
+	return { ...session, pausedAt: nowIso };
+}
+
+/**
+ * Resumes a paused session. The session total is frozen across the away gap by
+ * shifting `startedAt` forward by the paused duration, so `diffSec(startedAt)`
+ * returns the same value it had when the user left and keeps counting from
+ * there. The current block timer resets to 0 by re-anchoring
+ * `currentBlockStartedAt` to `nowIso`. No-op (same reference) when not paused.
+ */
+export function resumeSession(
+	session: ActiveSession,
+	nowIso: string,
+): ActiveSession {
+	if (!session.pausedAt) return session;
+	const now = parseTime(nowIso);
+	const pausedAt = parseTime(session.pausedAt);
+	const startedAt = parseTime(session.startedAt);
+	// Only shift the total anchor when every timestamp parses; otherwise leave
+	// `startedAt` untouched but still reset the block and clear the pause flag.
+	const shiftedStartedAt =
+		now !== null && pausedAt !== null && startedAt !== null
+			? new Date(startedAt + (now - pausedAt)).toISOString()
+			: session.startedAt;
+	return {
+		...session,
+		startedAt: shiftedStartedAt,
+		currentBlockStartedAt: nowIso,
+		pausedAt: null,
+	};
+}


### PR DESCRIPTION
Previously practice sessions would count from start time. Meaning if you stopped the app or went away from the page, it could display 135:33:25 time passed for the total and block. This would make it hard to figure out when you should stop.

Fixes #53 